### PR TITLE
Add `to_events()` on `DGraph`

### DIFF
--- a/opendg/graph.py
+++ b/opendg/graph.py
@@ -100,12 +100,21 @@ class DGraph:
             time_col (str): Column in the dataframe corresponding to the timestamp.
             edge_feature_col (Optional[List[str]]): Column list in the csv corresponding to the edge features.
         """
-        events = self._storage.to_events(
+        events = self.to_events()
+        write_csv(events, file_path, src_col, dst_col, time_col, edge_feature_col)
+
+    def to_events(self) -> List[Event]:
+        r"""Materialize the events in the DGraph.
+
+        Returns:
+            List of events in the current DGraph. Events are ordered by time, but event ordering
+            within a single timestamp is not deterministic.
+        """
+        return self._storage.to_events(
             start_time=self._cache.get('start_time'),
             end_time=self._cache.get('end_time'),
             node_slice=self._cache.get('node_slice'),
         )
-        write_csv(events, file_path, src_col, dst_col, time_col, edge_feature_col)
 
     def slice_time(
         self, start_time: Optional[int] = None, end_time: Optional[int] = None

--- a/test/test_dgraph.py
+++ b/test/test_dgraph.py
@@ -78,6 +78,55 @@ def test_init_bad_constructor_args(events):
         DGraph(events=events, _storage=dg_tmp._storage)
 
 
+def test_to_events():
+    events = [
+        EdgeEvent(time=1, edge=(2, 2)),
+        EdgeEvent(time=5, edge=(2, 4)),
+        EdgeEvent(time=20, edge=(1, 8)),
+    ]
+    dg = DGraph(events=events)
+    _assert_events_equal(dg.to_events(), events)
+
+
+@pytest.mark.skip('Node feature IO not implemented')
+def test_to_events_with_node_events():
+    events = [
+        NodeEvent(time=1, node_id=2),
+        EdgeEvent(time=1, edge=(2, 2)),
+        NodeEvent(time=5, node_id=4),
+        EdgeEvent(time=5, edge=(2, 4)),
+        NodeEvent(time=10, node_id=6),
+        EdgeEvent(time=20, edge=(1, 8)),
+    ]
+    dg = DGraph(events=events)
+    _assert_events_equal(dg.to_events(), events)
+
+
+def test_to_events_with_cache():
+    events = [
+        EdgeEvent(time=1, edge=(2, 2)),
+        EdgeEvent(time=5, edge=(2, 4)),
+        EdgeEvent(time=20, edge=(1, 8)),
+    ]
+    dg = DGraph(events=events)
+    dg._cache['start_time'] = 5
+    _assert_events_equal(dg.to_events(), events[1:])
+
+    dg._cache.clear()
+    dg._cache['node_slice'] = set([2])
+    _assert_events_equal(dg.to_events(), events[:2])
+
+
+def test_to_events_with_features():
+    events = [
+        EdgeEvent(time=1, edge=(2, 2), features=torch.rand(2)),
+        EdgeEvent(time=5, edge=(2, 4), features=torch.rand(2)),
+        EdgeEvent(time=20, edge=(1, 8), features=torch.rand(2)),
+    ]
+    dg = DGraph(events=events)
+    _assert_events_equal(dg.to_events(), events)
+
+
 def test_to_csv():
     events = [
         EdgeEvent(time=1, edge=(2, 2)),


### PR DESCRIPTION
Close #58 


### Main Purpose
The purpose of this PR is to add the `to_events()` method to the `DGraph` API. It is already something we used internally for materialization to csv. 