### PR TITLE
Granularity Comparison for `TimeDeltaDG` and `TimeDeltaUnit`

### DIFF
--- a/opendg/graph.py
+++ b/opendg/graph.py
@@ -7,7 +7,7 @@ from torch import Tensor
 from opendg._io import read_csv, read_pandas, write_csv
 from opendg._storage import DGStorage, DGStorageBase
 from opendg.events import Event
-from opendg.timedelta import TimeDeltaDG
+from opendg.timedelta import TimeDeltaDG, TimeDeltaUnit
 
 
 class DGraph:
@@ -377,7 +377,7 @@ class DGraph:
         self, time_delta: Optional[TimeDeltaDG]
     ) -> 'TimeDeltaDG':
         if time_delta is None:
-            return TimeDeltaDG('r')  # Default to ordered granularity
+            return TimeDeltaDG(TimeDeltaUnit.ORDERED)  # Default to ordered granularity
         if not isinstance(time_delta, TimeDeltaDG):
             raise ValueError(
                 f'Expected time_delta to be of type TimeDeltaDG, but got: {type(time_delta)}'

--- a/opendg/timedelta.py
+++ b/opendg/timedelta.py
@@ -63,6 +63,23 @@ class TimeDeltaDG:
         r"""Whether or not the time granularity is 'ordered', in which case conversions are prohibited."""
         return self.unit == TimeDeltaUnit.ORDERED
 
+    def is_more_granular_than(self, other: Union[str, 'TimeDeltaDG']) -> bool:
+        r"""Return True iff self is strictly more granular than other.
+
+        Args:
+            other (Union[str, 'TimeDeltaDG']): The other time delta to compare to.
+
+        Raises:
+            ValueError if either self or other is TimeDeltaUnit.ORDERED.
+        """
+        if isinstance(other, str):
+            other = TimeDeltaDG(other)
+
+        if self.unit == TimeDeltaUnit.ORDERED or other.unit == TimeDeltaUnit.ORDERED:
+            raise ValueError('Cannot compare time granularity on TimeDeltaUnit.ORDERED')
+
+        return self.convert(other) < 1
+
     def convert(self, time_delta: Union[str, 'TimeDeltaDG']) -> float:
         r"""Convert the current granularity to the specified time_delta (either a unit string or a TimeDeltaDG object).
 
@@ -121,6 +138,23 @@ class TimeDeltaUnit(str, Enum):
 
     def __str__(self) -> str:
         return self.value
+
+    def is_more_granular_than(self, other: Union[str, 'TimeDeltaUnit']) -> bool:
+        r"""Return True iff self is strictly more granular than other.
+
+        Args:
+            other (Union[str, 'TimeDeltaUnit']): The other unit to compare to.
+
+        Raises:
+            ValueError if either self or other is TimeDeltaUnit.ORDERED.
+        """
+        if self == TimeDeltaUnit.ORDERED or other == TimeDeltaUnit.ORDERED:
+            raise ValueError('Cannot compare time granularity on TimeDeltaUnit.ORDERED')
+
+        other = TimeDeltaUnit.from_string(other)
+
+        units = TimeDeltaUnit._member_names_
+        return units.index(self.name) < units.index(other.name)
 
     @classmethod
     def from_string(cls, s: str) -> 'TimeDeltaUnit':

--- a/opendg/timedelta.py
+++ b/opendg/timedelta.py
@@ -63,8 +63,8 @@ class TimeDeltaDG:
         r"""Whether or not the time granularity is 'ordered', in which case conversions are prohibited."""
         return self.unit == TimeDeltaUnit.ORDERED
 
-    def is_more_granular_than(self, other: Union[str, 'TimeDeltaDG']) -> bool:
-        r"""Return True iff self is strictly more granular than other.
+    def is_coarser_than(self, other: Union[str, 'TimeDeltaDG']) -> bool:
+        r"""Return True iff self is strictly coarser than other.
 
         Args:
             other (Union[str, 'TimeDeltaDG']): The other time delta to compare to.
@@ -78,7 +78,7 @@ class TimeDeltaDG:
         if self.unit == TimeDeltaUnit.ORDERED or other.unit == TimeDeltaUnit.ORDERED:
             raise ValueError('Cannot compare time granularity on TimeDeltaUnit.ORDERED')
 
-        return self.convert(other) < 1
+        return self.convert(other) > 1
 
     def convert(self, time_delta: Union[str, 'TimeDeltaDG']) -> float:
         r"""Convert the current granularity to the specified time_delta (either a unit string or a TimeDeltaDG object).
@@ -139,8 +139,8 @@ class TimeDeltaUnit(str, Enum):
     def __str__(self) -> str:
         return self.value
 
-    def is_more_granular_than(self, other: Union[str, 'TimeDeltaUnit']) -> bool:
-        r"""Return True iff self is strictly more granular than other.
+    def is_coarser_than(self, other: Union[str, 'TimeDeltaUnit']) -> bool:
+        r"""Return True iff self is strictly coarser than other.
 
         Args:
             other (Union[str, 'TimeDeltaUnit']): The other unit to compare to.
@@ -154,7 +154,7 @@ class TimeDeltaUnit(str, Enum):
         other = TimeDeltaUnit.from_string(other)
 
         units = TimeDeltaUnit._member_names_
-        return units.index(self.name) < units.index(other.name)
+        return units.index(self.name) > units.index(other.name)
 
     @classmethod
     def from_string(cls, s: str) -> 'TimeDeltaUnit':

--- a/test/test_timedelta.py
+++ b/test/test_timedelta.py
@@ -26,7 +26,7 @@ def test_init_non_default_value(time_granularity):
 
 
 def test_init_ordered():
-    time_granularity = 'r'
+    time_granularity = TimeDeltaUnit.ORDERED
     td = TimeDeltaDG(time_granularity)
     assert td.unit == time_granularity
     assert td.value == 1
@@ -67,7 +67,7 @@ def test_init_bad_value(time_granularity, bad_value):
 @pytest.mark.parametrize('bad_value', [-1, 0, 2])
 def test_init_ordered_bad_value(bad_value):
     # Note: Only '1' accepted as the value for an ordered type
-    time_granularity = 'r'
+    time_granularity = TimeDeltaUnit.ORDERED
     with pytest.raises(ValueError):
         _ = TimeDeltaDG(time_granularity, bad_value)
 
@@ -171,7 +171,7 @@ def test_convert_between_different_units():
 
 
 def test_bad_convert_from_ordered():
-    td1 = TimeDeltaDG('r')
+    td1 = TimeDeltaDG(TimeDeltaUnit.ORDERED)
     td2 = TimeDeltaDG('Y', 1)
 
     with pytest.raises(ValueError):
@@ -180,7 +180,119 @@ def test_bad_convert_from_ordered():
 
 def test_bad_convert_to_ordered():
     td1 = TimeDeltaDG('Y', 1)
-    td2 = TimeDeltaDG('r')
+    td2 = TimeDeltaDG(TimeDeltaUnit.ORDERED)
 
     with pytest.raises(ValueError):
         _ = td1.convert(td2)
+
+
+def test_time_delta_is_more_granular_than():
+    td1 = TimeDeltaDG('s', value=30)
+    td2 = TimeDeltaDG('m')
+
+    assert td1.is_more_granular_than(td2)
+    assert td1.is_more_granular_than('m')
+
+
+def test_time_delta_is_more_granular_than_due_to_value():
+    # Testing that granularity is not just based on the unit.
+    # In this case, 1 minute should be more granular than 80 seconds
+    # even though TimeDeltaUnit.SECOND is more granular than TimeDeltaUnit.MINUTE
+    td1 = TimeDeltaDG('s', value=80)
+    td2 = TimeDeltaDG('m')
+
+    assert td2.is_more_granular_than(td1)
+
+
+def test_time_delta_is_not_more_granular_than():
+    td1 = TimeDeltaDG('s')
+
+    assert not td1.is_more_granular_than(td1)  # Strict granularity
+    assert not td1.is_more_granular_than('s')
+
+    td2 = TimeDeltaDG('ms', value=300)
+
+    assert not td1.is_more_granular_than(td2)
+    assert not td1.is_more_granular_than('ms')
+
+
+def test_time_delta_is_more_granular_try_compare_ordered():
+    td1 = TimeDeltaDG('r')
+    td2 = TimeDeltaDG('s')
+
+    with pytest.raises(ValueError):
+        td1.is_more_granular_than(td2)
+
+    with pytest.raises(ValueError):
+        td2.is_more_granular_than(td1)
+
+    with pytest.raises(ValueError):
+        td1.is_more_granular_than('r')
+
+
+def test_time_unit_ordering():
+    # This ensures consistent ordering behaviour between units.
+    # The convention we use is that we order from more granular (smaller unit) to less granular (larger unit).
+    units = TimeDeltaUnit._member_names_
+    assert units == [
+        'ORDERED',
+        'NANOSECOND',
+        'MICROSECOND',
+        'MILLISECOND',
+        'SECOND',
+        'MINUTE',
+        'HOUR',
+        'DAY',
+        'WEEK',
+        'MONTH',
+        'YEAR',
+    ]
+
+
+def test_time_unit_is_more_granular_than():
+    # Start i at index 1 since ORDERED enum value is not comparable (see test cases below)
+    for i in range(1, len(TimeDeltaUnit._member_names_)):
+        for j in range(i, len(TimeDeltaUnit._member_names_)):
+            unit_i = TimeDeltaUnit.from_string(TimeDeltaUnit._member_names_[i])
+            unit_j = TimeDeltaUnit.from_string(TimeDeltaUnit._member_names_[j])
+
+            if i == j:
+                assert not unit_i.is_more_granular_than(unit_j)
+                assert not unit_j.is_more_granular_than(unit_i)
+            else:
+                assert unit_i.is_more_granular_than(unit_j)
+                assert not unit_j.is_more_granular_than(unit_i)
+
+
+def test_time_unit_is_more_granular_than_with_string():
+    # Start i at index 1 since ORDERED enum value is not comparable (see test cases below)
+    for i in range(1, len(TimeDeltaUnit._member_names_)):
+        for j in range(i, len(TimeDeltaUnit._member_names_)):
+            unit_i = TimeDeltaUnit.from_string(TimeDeltaUnit._member_names_[i])
+            unit_j = TimeDeltaUnit.from_string(TimeDeltaUnit._member_names_[j])
+
+            if i == j:
+                assert not unit_i.is_more_granular_than(TimeDeltaUnit._member_names_[j])
+                assert not unit_j.is_more_granular_than(TimeDeltaUnit._member_names_[i])
+            else:
+                assert unit_i.is_more_granular_than(TimeDeltaUnit._member_names_[j])
+                assert not unit_j.is_more_granular_than(TimeDeltaUnit._member_names_[i])
+
+
+def test_time_unit_is_more_granular_than_with_ordered(time_granularity):
+    unit = TimeDeltaUnit.from_string(time_granularity)
+    with pytest.raises(ValueError):
+        unit.is_more_granular_than(TimeDeltaUnit.ORDERED)
+
+    unit = TimeDeltaUnit.from_string(time_granularity)
+    with pytest.raises(ValueError):
+        TimeDeltaUnit.ORDERED.is_more_granular_than(unit)
+
+
+def test_time_unit_is_more_granular_than_with_ordered_string(time_granularity):
+    unit = TimeDeltaUnit.from_string(time_granularity)
+    with pytest.raises(ValueError):
+        unit.is_more_granular_than('r')
+
+    with pytest.raises(ValueError):
+        TimeDeltaUnit.ORDERED.is_more_granular_than(time_granularity)

--- a/test/test_timedelta.py
+++ b/test/test_timedelta.py
@@ -186,48 +186,46 @@ def test_bad_convert_to_ordered():
         _ = td1.convert(td2)
 
 
-def test_time_delta_is_more_granular_than():
+def test_time_delta_is_coarser_than():
     td1 = TimeDeltaDG('s', value=30)
     td2 = TimeDeltaDG('m')
+    assert td2.is_coarser_than(td1)
+    assert not td1.is_coarser_than('m')
 
-    assert td1.is_more_granular_than(td2)
-    assert td1.is_more_granular_than('m')
+    # Check that comparison is strict
+    td1 = TimeDeltaDG('s')
+    assert not td1.is_coarser_than(td1)
+    assert not td1.is_coarser_than('s')
+
+    # Check that the 'value' is taken into account (not just unit)
+    td1 = TimeDeltaDG('s', value=60 * 5)
+    td2 = TimeDeltaDG('m', value=3)
+    assert td1.is_coarser_than(td2)
+    assert not td2.is_coarser_than(td1)
 
 
-def test_time_delta_is_more_granular_than_due_to_value():
+def test_time_delta_is_coarser_than_due_to_value():
     # Testing that granularity is not just based on the unit.
     # In this case, 1 minute should be more granular than 80 seconds
     # even though TimeDeltaUnit.SECOND is more granular than TimeDeltaUnit.MINUTE
     td1 = TimeDeltaDG('s', value=80)
     td2 = TimeDeltaDG('m')
-
-    assert td2.is_more_granular_than(td1)
-
-
-def test_time_delta_is_not_more_granular_than():
-    td1 = TimeDeltaDG('s')
-
-    assert not td1.is_more_granular_than(td1)  # Strict granularity
-    assert not td1.is_more_granular_than('s')
-
-    td2 = TimeDeltaDG('ms', value=300)
-
-    assert not td1.is_more_granular_than(td2)
-    assert not td1.is_more_granular_than('ms')
+    assert not td2.is_coarser_than(td1)
+    assert td1.is_coarser_than(td2)
 
 
-def test_time_delta_is_more_granular_try_compare_ordered():
+def test_time_delta_is_coarser_try_compare_ordered():
     td1 = TimeDeltaDG('r')
     td2 = TimeDeltaDG('s')
 
     with pytest.raises(ValueError):
-        td1.is_more_granular_than(td2)
+        td1.is_coarser_than(td2)
 
     with pytest.raises(ValueError):
-        td2.is_more_granular_than(td1)
+        td2.is_coarser_than(td1)
 
     with pytest.raises(ValueError):
-        td1.is_more_granular_than('r')
+        td1.is_coarser_than('r')
 
 
 def test_time_unit_ordering():
@@ -249,7 +247,7 @@ def test_time_unit_ordering():
     ]
 
 
-def test_time_unit_is_more_granular_than():
+def test_time_unit_is_coarser_than():
     # Start i at index 1 since ORDERED enum value is not comparable (see test cases below)
     for i in range(1, len(TimeDeltaUnit._member_names_)):
         for j in range(i, len(TimeDeltaUnit._member_names_)):
@@ -257,14 +255,14 @@ def test_time_unit_is_more_granular_than():
             unit_j = TimeDeltaUnit.from_string(TimeDeltaUnit._member_names_[j])
 
             if i == j:
-                assert not unit_i.is_more_granular_than(unit_j)
-                assert not unit_j.is_more_granular_than(unit_i)
+                assert not unit_i.is_coarser_than(unit_j)
+                assert not unit_j.is_coarser_than(unit_i)
             else:
-                assert unit_i.is_more_granular_than(unit_j)
-                assert not unit_j.is_more_granular_than(unit_i)
+                assert not unit_i.is_coarser_than(unit_j)
+                assert unit_j.is_coarser_than(unit_i)
 
 
-def test_time_unit_is_more_granular_than_with_string():
+def test_time_unit_is_coarser_than_with_string():
     # Start i at index 1 since ORDERED enum value is not comparable (see test cases below)
     for i in range(1, len(TimeDeltaUnit._member_names_)):
         for j in range(i, len(TimeDeltaUnit._member_names_)):
@@ -272,27 +270,27 @@ def test_time_unit_is_more_granular_than_with_string():
             unit_j = TimeDeltaUnit.from_string(TimeDeltaUnit._member_names_[j])
 
             if i == j:
-                assert not unit_i.is_more_granular_than(TimeDeltaUnit._member_names_[j])
-                assert not unit_j.is_more_granular_than(TimeDeltaUnit._member_names_[i])
+                assert not unit_i.is_coarser_than(TimeDeltaUnit._member_names_[j])
+                assert not unit_j.is_coarser_than(TimeDeltaUnit._member_names_[i])
             else:
-                assert unit_i.is_more_granular_than(TimeDeltaUnit._member_names_[j])
-                assert not unit_j.is_more_granular_than(TimeDeltaUnit._member_names_[i])
+                assert not unit_i.is_coarser_than(TimeDeltaUnit._member_names_[j])
+                assert unit_j.is_coarser_than(TimeDeltaUnit._member_names_[i])
 
 
-def test_time_unit_is_more_granular_than_with_ordered(time_granularity):
+def test_time_unit_is_coarser_than_with_ordered(time_granularity):
     unit = TimeDeltaUnit.from_string(time_granularity)
     with pytest.raises(ValueError):
-        unit.is_more_granular_than(TimeDeltaUnit.ORDERED)
+        unit.is_coarser_than(TimeDeltaUnit.ORDERED)
 
     unit = TimeDeltaUnit.from_string(time_granularity)
     with pytest.raises(ValueError):
-        TimeDeltaUnit.ORDERED.is_more_granular_than(unit)
+        TimeDeltaUnit.ORDERED.is_coarser_than(unit)
 
 
-def test_time_unit_is_more_granular_than_with_ordered_string(time_granularity):
+def test_time_unit_is_coarser_than_with_ordered_string(time_granularity):
     unit = TimeDeltaUnit.from_string(time_granularity)
     with pytest.raises(ValueError):
-        unit.is_more_granular_than('r')
+        unit.is_coarser_than('r')
 
     with pytest.raises(ValueError):
-        TimeDeltaUnit.ORDERED.is_more_granular_than(time_granularity)
+        TimeDeltaUnit.ORDERED.is_coarser_than(time_granularity)


### PR DESCRIPTION
Close #60 

### Main Purpose
This PR adds the `is_more_granular_than` method on both the `TimeDeltaDG` and `TimeDeltaUnit`. This enables comparison between granularities which is needed for dataloading and temporal coarsening.

### Notes
- This was taken directly from #53 in order to split up the PR and make it easier to review