### PR TITLE
Fix slow dgraph copies

### DIFF
--- a/opendg/graph.py
+++ b/opendg/graph.py
@@ -1,4 +1,3 @@
-import copy
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -135,8 +134,8 @@ class DGraph:
         new_start_time, new_end_time = self._check_slice_time_args(start_time, end_time)
         new_end_time -= 1  # Because slicing is end range exclusive
 
-        dg = copy.copy(self)
-        dg._cache = copy.deepcopy(self._cache)  # Deep copy cache to avoid dict alias
+        dg = DGraph(time_delta=self.time_delta, _storage=self._storage)
+        dg._cache = dict(self._cache)  # Deep copy cache to avoid dict alias
 
         if self.start_time is not None and self.start_time > new_start_time:
             new_start_time = self.start_time
@@ -168,9 +167,7 @@ class DGraph:
         Returns:
             DGraph copy of events related to the input nodes.
         """
-        dg = copy.copy(self)
-        dg._cache = copy.deepcopy(self._cache)  # Deep copy cache to avoid dict alias
-        dg._cache.clear()
+        dg = DGraph(time_delta=self.time_delta, _storage=self._storage)
 
         if self._cache.get('node_slice') is None:
             self._cache['node_slice'] = set(range(self.num_nodes))


### PR DESCRIPTION
Close #67 

### Purpose
This PR removes all `__copy__` calls in favour of our fast _copy constructor_ when performing shallow clones of the `DGraph`.

### Perf Results
Iterating a `DGraph` with 1M events:

#### Control (`openDG::main`)
![control](https://github.com/user-attachments/assets/fed0d0a6-ff80-410f-bbbd-791aafb6a493)

- notice we spend about 16s out of the 21s in `slice_time` making these copies.

#### Case (`openDG::bug/slow_copy`)
![case](https://github.com/user-attachments/assets/6a90964c-6378-4b0a-8e39-666e3f9b5dd2)

- not anymore