### PR TITLE
Throw ValueError if trying to iterate by events

### DIFF
--- a/opendg/loader/base.py
+++ b/opendg/loader/base.py
@@ -16,22 +16,8 @@ class DGBaseLoader(ABC):
     Raises:
         ValueError: If the batch_unit is not a valid TimeDeltaDG unit.
         ValueError: If the batch_size is not a positive integer.
-        ValueError: If the batch_unit is not ordered and the graph time unit is ordered.
-        ValueError: If both the batch_unit and the graph are not ordered, but the graph TimeDelta
-                    is coarser than the batch TimeDelta. In this case, there is ambiguity in how to yield
-                    events due to loss of information.
-
-    Note:
-        Ordered batch_unit iterates using normal batch size semantics
-        in which case each yielded batch has a constant number of events (except the last batch if drop_last=False).
-            e.g. batch_size=5, batch_unit='r'-> yield 5 events at time
-
-        Unordered batch_unit iterates uses the appropriate temporal unit in which case each yielded
-        batch may have different number of events but has the same temporal length (except the last batch if drop_last=False).
-            e.g. batch_size=5, batch_unit='s'-> yield 5 seconds of data at a time
-
-        When using the ordered batch_unit, the order of yielded _events within the same timestamp
-        is non-deterministic.
+        ValueError: If the batch_unit and dg time unit are not both ordered or both not ordered.
+        ValueError: If the batch_unit and dg time unit are both ordered but the graph is coarser than the batch.
     """
 
     def __init__(
@@ -43,19 +29,20 @@ class DGBaseLoader(ABC):
     ) -> None:
         if batch_size <= 0:
             raise ValueError(f'batch_size must be > 0 but got {batch_size}')
+        if not len(dg):
+            raise ValueError('Cannot iterate an empty DGraph')
 
         self._dg = dg
         self._batch_size = batch_size
         self._batch_unit = batch_unit
         self._drop_last = drop_last
-
         dg_is_ordered = self._dg.time_delta.is_ordered
         batch_unit_is_ordered = self._batch_unit == 'r'
 
         if dg_is_ordered and not batch_unit_is_ordered:
-            raise ValueError(
-                'Cannot use non-ordered batch_unit to iterate a DGraph with ordered time_delta'
-            )
+            raise ValueError('Cannot iterate ordered dg using non-ordered batch_unit')
+        if not dg_is_ordered and batch_unit_is_ordered:
+            raise ValueError('Cannot iterate non-ordered dg using ordered batch_unit')
 
         if not dg_is_ordered and not batch_unit_is_ordered:
             # Check to ensure the graph time unit is smaller (more granular) than batch time unit.
@@ -71,16 +58,8 @@ class DGBaseLoader(ABC):
 
             self._batch_size = int(batch_time_delta.convert(self._dg.time_delta))
 
-        # TODO: Check for time gap?
-        self._iterate_by_events = not dg_is_ordered and batch_unit_is_ordered
-
-        self._idx = 0
-        self._events = []
-        if self._iterate_by_events and len(self._dg):
-            self._events = self._dg._storage.to_events()
-        elif len(self._dg):
-            assert self._dg.start_time is not None
-            self._idx = self._dg.start_time
+        assert self._dg.start_time is not None
+        self._idx = self._dg.start_time
 
     @abstractmethod
     def sample(self, batch: 'DGraph') -> 'DGraph':
@@ -100,12 +79,7 @@ class DGBaseLoader(ABC):
         if self._done_iteration():
             raise StopIteration
 
-        if self._iterate_by_events:
-            events = self._events[self._idx : self._idx + self._batch_size]
-            batch = DGraph(events, time_delta=self._dg.time_delta)
-        else:
-            batch = self._dg.slice_time(self._idx, self._idx + self._batch_size - 1)
-
+        batch = self._dg.slice_time(self._idx, self._idx + self._batch_size - 1)
         self._idx += self._batch_size
         return self.sample(batch)
 
@@ -118,8 +92,5 @@ class DGBaseLoader(ABC):
         else:
             check_idx = self._idx
 
-        if self._iterate_by_events:
-            return check_idx >= len(self._events)
-        else:
-            assert self._dg.end_time is not None
-            return check_idx >= self._dg.end_time + 1
+        assert self._dg.end_time is not None
+        return check_idx >= self._dg.end_time + 1

--- a/opendg/loader/dataloader.py
+++ b/opendg/loader/dataloader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from opendg.graph import DGraph
 from opendg.loader.base import DGBaseLoader
 
@@ -5,13 +7,5 @@ from opendg.loader.base import DGBaseLoader
 class DGDataLoader(DGBaseLoader):
     r"""Load data from DGraph without any sampling."""
 
-    def sample(self, batch: 'DGraph') -> 'DGraph':
-        r"""DGDataLoader performs no subsampling. Returns the full batch.
-
-        Args:
-            batch (DGraph): Incoming batch of data. May not be materialized.
-
-        Returns:
-            (DGraph): The input batch of data.
-        """
+    def sample(self, batch: DGraph) -> DGraph:
         return batch

--- a/test/test_loader/test_dg_loader.py
+++ b/test/test_loader/test_dg_loader.py
@@ -11,7 +11,6 @@ def test_init_ordered_dg_ordered_batch():
     dg = DGraph(events)
     loader = DGDataLoader(dg)
     assert loader._batch_size == 1
-    assert loader._batch_unit == 'r'
 
 
 @pytest.mark.parametrize('batch_unit', ['Y', 'M', 'W', 'D', 'h', 's', 'ms', 'us', 'ns'])

--- a/test/test_loader/test_dg_loader.py
+++ b/test/test_loader/test_dg_loader.py
@@ -22,6 +22,14 @@ def test_init_ordered_dg_non_ordered_batch(batch_unit):
         _ = DGDataLoader(dg, batch_unit=batch_unit)
 
 
+@pytest.mark.parametrize('batch_unit', ['Y', 'M', 'W', 'D', 'h', 's', 'ms', 'us', 'ns'])
+def test_init_non_ordered_dg_ordered_batch(batch_unit):
+    events = [EdgeEvent(t=1, src=2, dst=3)]
+    dg = DGraph(events, time_delta=TimeDeltaDG(batch_unit))
+    with pytest.raises(ValueError):
+        _ = DGDataLoader(dg)
+
+
 @pytest.mark.parametrize(
     'batch_unit', ['r', 'Y', 'M', 'W', 'D', 'h', 's', 'ms', 'us', 'ns']
 )
@@ -200,56 +208,3 @@ def test_iteration_non_ordered_dg_non_ordered_batch_unit_too_granular():
     with pytest.raises(ValueError):
         # Seconds are too granular of an iteration unit for DG with 'every 30 seconds' time granularity
         _ = DGDataLoader(dg, batch_unit='s')
-
-
-@pytest.mark.parametrize('batch_unit', ['Y', 'M', 'W', 'D', 'h', 's', 'ms', 'us', 'ns'])
-@pytest.mark.parametrize('drop_last', [True, False])
-def test_iteration_non_ordered_dg_ordered_batch(batch_unit, drop_last):
-    events = [
-        EdgeEvent(t=0, src=1, dst=2),
-        EdgeEvent(t=0, src=2, dst=3),
-        EdgeEvent(t=0, src=3, dst=4),
-        EdgeEvent(t=1, src=4, dst=5),
-        EdgeEvent(t=1, src=5, dst=6),
-        EdgeEvent(t=2, src=6, dst=7),
-        EdgeEvent(t=2, src=7, dst=8),
-        EdgeEvent(t=3, src=8, dst=9),
-        EdgeEvent(t=4, src=9, dst=10),
-    ]
-    dg = DGraph(events, time_delta=TimeDeltaDG(batch_unit))
-    loader = DGDataLoader(dg, batch_size=3, drop_last=drop_last)
-
-    batch_num = 0
-    for batch in loader:
-        assert isinstance(batch, DGraph)
-        assert batch.to_events() == events[3 * batch_num : 3 * (batch_num + 1)]
-        batch_num += 1
-
-    assert batch_num == 3
-
-
-@pytest.mark.parametrize('batch_unit', ['Y', 'M', 'W', 'D', 'h', 's', 'ms', 'us', 'ns'])
-@pytest.mark.parametrize('drop_last', [True, False])
-def test_iteration_non_ordered_dg_ordered_batch_size_1(batch_unit, drop_last):
-    events = [
-        EdgeEvent(t=0, src=1, dst=2),
-        EdgeEvent(t=0, src=2, dst=3),
-        EdgeEvent(t=0, src=3, dst=4),
-        EdgeEvent(t=1, src=4, dst=5),
-        EdgeEvent(t=1, src=5, dst=6),
-        EdgeEvent(t=2, src=6, dst=7),
-        EdgeEvent(t=2, src=7, dst=8),
-        EdgeEvent(t=3, src=8, dst=9),
-        EdgeEvent(t=4, src=9, dst=10),
-    ]
-    dg = DGraph(events, time_delta=TimeDeltaDG(batch_unit))
-    loader = DGDataLoader(dg, batch_size=1, drop_last=drop_last)
-
-    batch_num = 0
-    for batch in loader:
-        assert isinstance(batch, DGraph)
-        assert len(batch) == 1
-        assert batch.to_events() == [events[batch_num]]
-        batch_num += 1
-
-    assert batch_num == len(events)


### PR DESCRIPTION
Close #86 

### Purpose
This purpose of this PR is to throw a `ValueError` if trying to iterate a _non-ordered_ `DGraph` using an _ordered_ batch unit. Previously, I wrote a _hacky_ solution which materializes the storage into an events list and iterates it for the user.

There are several reasons why this doesn't makes sense
1. We already prevent the user from iterating a _ordered_ `DGraph` using a _non-ordered_ batch unit (in this case, there is not way to do it conceptually even). With these changes, the semenatics are much more clear: use the right ordered/non-ordered batch unit depending on your graph.
2. It is extremely slow. Materializing the full events and then constructing a completely new storage on each batch makes no sense. 
3. We can still get the _non-ordered_ batch behaviour by converting the dgraph to ordered (using coarsening which is not implemented yet, but will be a utility).
4. It simplifies the code a bunch, as you can see. Now, we can fully pre-fetch the entire set of slice calls that we need to make by just walking the DGraph index. This will enable some good optimization in a subsequent PR.