### PR TITLE
Take advantage of sorted events in `ArrayBackend`

### DIFF
--- a/opendg/_storage/backends/array_backend.py
+++ b/opendg/_storage/backends/array_backend.py
@@ -1,6 +1,7 @@
 import random
 from typing import Dict, List, Optional, Set, Tuple
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -16,6 +17,11 @@ class DGStorageArrayBackend(DGStorageBase):
         self._node_feats_shape = self._check_node_feature_shapes(events)
         self._edge_feats_shape = self._check_edge_feature_shapes(events)
         self._events = self._sort_events_list_if_needed(events[:])  # Make a copy
+        self._ts = np.array([event.t for event in self._events])
+
+        # TODO: try to bypass functools lru cache restrictions on ndarrays
+        self._lb_idx_cache: Dict[Optional[int], int] = {}
+        self._ub_idx_cache: Dict[Optional[int], int] = {}
 
     def to_events(
         self,
@@ -23,16 +29,27 @@ class DGStorageArrayBackend(DGStorageBase):
         end_time: Optional[int] = None,
         node_slice: Optional[Set[int]] = None,
     ) -> List[Event]:
-        events: List[Event] = []
-        for event in self._events:
-            if self._valid_slice(event, start_time, end_time, node_slice):
+        if not len(self._events):
+            return []
+
+        lb_idx, ub_idx = self._lb_time_idx(start_time), self._ub_time_idx(end_time)
+        if node_slice is None:
+            return self._events[lb_idx:ub_idx]
+
+        events = []
+        for i in range(lb_idx, ub_idx):
+            event = self._events[i]
+            if event.src in node_slice:
+                events.append(event)
+            elif isinstance(event, EdgeEvent) and event.dst in node_slice:
                 events.append(event)
         return events
 
     def get_start_time(self, node_slice: Optional[Set[int]] = None) -> Optional[int]:
         start_time = None
         for event in self._events:
-            if self._valid_slice(event, node_slice=node_slice):
+            event_nodes = (event.src,) if isinstance(event, NodeEvent) else event.edge
+            if node_slice is None or len(node_slice.intersection(event_nodes)):
                 if start_time is None or event.t < start_time:
                     start_time = event.t
         return start_time
@@ -40,7 +57,8 @@ class DGStorageArrayBackend(DGStorageBase):
     def get_end_time(self, node_slice: Optional[Set[int]] = None) -> Optional[int]:
         end_time = None
         for event in self._events:
-            if self._valid_slice(event, node_slice=node_slice):
+            event_nodes = (event.src,) if isinstance(event, NodeEvent) else event.edge
+            if node_slice is None or len(node_slice.intersection(event_nodes)):
                 if end_time is None or event.t > end_time:
                     end_time = event.t
         return end_time
@@ -51,16 +69,17 @@ class DGStorageArrayBackend(DGStorageBase):
         end_time: Optional[int] = None,
         node_slice: Optional[Set[int]] = None,
     ) -> Set[int]:
-        nodes = set()
-        for event in self._events:
-            if self._valid_slice(
-                event, start_time=start_time, end_time=end_time, node_slice=node_slice
-            ):
-                if isinstance(event, NodeEvent):
-                    nodes.add(event.src)
-                elif isinstance(event, EdgeEvent):
-                    nodes.add(event.src)
-                    nodes.add(event.dst)
+        if not len(self._events):
+            return set()
+
+        lb_idx, ub_idx = self._lb_time_idx(start_time), self._ub_time_idx(end_time)
+
+        nodes: Set[int] = set()
+        for i in range(lb_idx, ub_idx):
+            event = self._events[i]
+            event_nodes = (event.src,) if isinstance(event, NodeEvent) else event.edge
+            if node_slice is None or len(node_slice.intersection(event_nodes)):
+                nodes.update(event_nodes)
         return nodes
 
     def get_num_edges(
@@ -69,15 +88,17 @@ class DGStorageArrayBackend(DGStorageBase):
         end_time: Optional[int] = None,
         node_slice: Optional[Set[int]] = None,
     ) -> int:
+        if not len(self._events):
+            return 0
+
+        lb_idx, ub_idx = self._lb_time_idx(start_time), self._ub_time_idx(end_time)
+
         edges = set()
-        for event in self._events:
-            if isinstance(event, EdgeEvent) and self._valid_slice(
-                event,
-                start_time=start_time,
-                end_time=end_time,
-                node_slice=node_slice,
-            ):
-                edges.add((event.t, event.edge))
+        for i in range(lb_idx, ub_idx):
+            event = self._events[i]
+            if isinstance(event, EdgeEvent):
+                if node_slice is None or len(node_slice.intersection(event.edge)):
+                    edges.add((event.t, event.edge))
         return len(edges)
 
     def get_num_timestamps(
@@ -86,14 +107,16 @@ class DGStorageArrayBackend(DGStorageBase):
         end_time: Optional[int] = None,
         node_slice: Optional[Set[int]] = None,
     ) -> int:
+        if not len(self._events):
+            return 0
+
+        lb_idx, ub_idx = self._lb_time_idx(start_time), self._ub_time_idx(end_time)
+
         timestamps = set()
-        for event in self._events:
-            if self._valid_slice(
-                event,
-                start_time=start_time,
-                end_time=end_time,
-                node_slice=node_slice,
-            ):
+        for i in range(lb_idx, ub_idx):
+            event = self._events[i]
+            event_nodes = (event.src,) if isinstance(event, NodeEvent) else event.edge
+            if node_slice is None or len(node_slice.intersection(event_nodes)):
                 timestamps.add(event.t)
         return len(timestamps)
 
@@ -105,6 +128,7 @@ class DGStorageArrayBackend(DGStorageBase):
         end_time: Optional[int] = None,
         node_slice: Optional[Set[int]] = None,
     ) -> Dict[int, List[List[Tuple[int, int]]]]:
+        # TODO: Take in a sample_func to enable more than uniform sampling
         if len(num_nbrs) > 1:
             raise NotImplementedError(
                 f'Multi-hop not impemented for {self.__class__.__name__}'
@@ -112,23 +136,28 @@ class DGStorageArrayBackend(DGStorageBase):
 
         seed_nodes_set = set(seed_nodes)
 
-        # TODO: Multi-hop
-        hop = 0
         nbrs: Dict[int, List[Set[Tuple[int, int]]]] = {
             node: [set()] for node in seed_nodes
         }
-        for event in self._events:
-            if isinstance(event, EdgeEvent) and self._valid_slice(
-                event, start_time, end_time, node_slice
-            ):
-                src, dst, t = event.src, event.dst, event.t
-                if src in seed_nodes_set:
-                    nbrs[src][hop].add((dst, t))
-                if dst in seed_nodes_set:
-                    nbrs[dst][hop].add((src, t))
+        sampled_nbrs: Dict[int, List[List[Tuple[int, int]]]] = {
+            node: [[]] for node in seed_nodes_set
+        }
+        if not len(self._events):
+            return sampled_nbrs
 
-        # TODO: Take in a sample_func to enable more than uniform sampling
-        sampled_nbrs: Dict[int, List[List[Tuple[int, int]]]] = {}
+        lb_idx, ub_idx = self._lb_time_idx(start_time), self._ub_time_idx(end_time)
+
+        hop = 0
+        for i in range(lb_idx, ub_idx):
+            event = self._events[i]
+            if isinstance(event, EdgeEvent):
+                if node_slice is None or len(node_slice.intersection(event.edge)):
+                    src, dst, t = event.src, event.dst, event.t
+                    if src in seed_nodes_set:
+                        nbrs[src][hop].add((dst, t))
+                    if dst in seed_nodes_set:
+                        nbrs[dst][hop].add((src, t))
+
         for node, nbrs_list in nbrs.items():
             node_nbrs = list(nbrs_list[hop])
             if num_nbrs[hop] != -1 and len(node_nbrs) > num_nbrs[hop]:
@@ -142,39 +171,35 @@ class DGStorageArrayBackend(DGStorageBase):
         end_time: Optional[int] = None,
         node_slice: Optional[Set[int]] = None,
     ) -> Optional[Tensor]:
+        if not len(self._events):
+            return None
+
+        lb_idx, ub_idx = self._lb_time_idx(start_time), self._ub_time_idx(end_time)
+
         # Assuming these are both non-negative
         max_time, max_node_id = -1, -1
 
         indices, values = [], []
-        for event in self._events:
-            if self._valid_slice(
-                event, start_time=start_time, end_time=end_time, node_slice=node_slice
-            ):
-                if isinstance(event, NodeEvent):
-                    max_time = max(max_time, event.t)
-                    max_node_id = max(max_node_id, event.src)
-
-                    if event.msg is not None:
-                        indices.append([event.t, event.src])
-                        values.append(event.msg)
-
-                elif isinstance(event, EdgeEvent):
-                    max_time = max(max_time, event.t)
-                    max_node_id = max(max_node_id, event.src, event.dst)
+        for i in range(lb_idx, ub_idx):
+            event = self._events[i]
+            event_nodes = (event.src,) if isinstance(event, NodeEvent) else event.edge
+            if node_slice is None or len(node_slice.intersection(event_nodes)):
+                max_time = max(max_time, event.t)
+                max_node_id = max(max_node_id, *event_nodes)
+                if isinstance(event, NodeEvent) and event.msg is not None:
+                    indices.append([event.t, event.src])
+                    values.append(event.msg)
 
         if not len(values):
             return None
 
         # If the end_time is given, then it determines the dimension of the temporal axis
-        # This is true even if there are no events at the end time, which could occur after
-        # calling slice_time on a graph.
+        # even if there are no events at the end time (could be the case after calling slice_time)
         max_time = end_time if end_time is not None else max_time
 
+        # https://pytorch.org/docs/stable/sparse.html#construction
         values_tensor = torch.stack(values)
-        indices_tensor = torch.tensor(
-            indices
-        ).t()  # https://pytorch.org/docs/stable/sparse.html#construction
-
+        indices_tensor = torch.tensor(indices).t()
         assert self._node_feats_shape is not None
         shape = (max_time + 1, max_node_id + 1, *self._node_feats_shape)
 
@@ -186,40 +211,36 @@ class DGStorageArrayBackend(DGStorageBase):
         end_time: Optional[int] = None,
         node_slice: Optional[Set[int]] = None,
     ) -> Optional[Tensor]:
+        if not len(self._events):
+            return None
+
+        lb_idx, ub_idx = self._lb_time_idx(start_time), self._ub_time_idx(end_time)
+
         # Assuming these are both non-negative
         max_time, max_node_id = -1, -1
 
         indices, values = [], []
-        for event in self._events:
-            if self._valid_slice(
-                event, start_time=start_time, end_time=end_time, node_slice=node_slice
-            ):
-                if isinstance(event, NodeEvent):
-                    max_time = max(max_time, event.t)
-                    max_node_id = max(max_node_id, event.src)
-                elif isinstance(event, EdgeEvent):
-                    max_time = max(max_time, event.t)
-                    max_node_id = max(max_node_id, event.src, event.dst)
-
-                    if event.msg is not None:
-                        indices.append([event.t, event.src, event.dst])
-                        values.append(event.msg)
+        for i in range(lb_idx, ub_idx):
+            event = self._events[i]
+            event_nodes = (event.src,) if isinstance(event, NodeEvent) else event.edge
+            if node_slice is None or len(node_slice.intersection(event_nodes)):
+                max_time = max(max_time, event.t)
+                max_node_id = max(max_node_id, *event_nodes)
+                if isinstance(event, EdgeEvent) and event.msg is not None:
+                    indices.append([event.t, event.src, event.dst])
+                    values.append(event.msg)
 
         if not len(values):
             return None
 
-        values_tensor = torch.stack(values)
-        indices_tensor = torch.tensor(
-            indices
-        ).t()  # https://pytorch.org/docs/stable/sparse.html#construction
-
-        assert self._edge_feats_shape is not None
-
         # If the end_time is given, then it determines the dimension of the temporal axis
-        # This is true even if there are no events at the end time, which could occur after
-        # calling slice_time on a graph.
+        # even if there are no events at the end time (could be the case after calling slice_time)
         max_time = end_time if end_time is not None else max_time
 
+        # https://pytorch.org/docs/stable/sparse.html#construction
+        values_tensor = torch.stack(values)
+        indices_tensor = torch.tensor(indices).t()
+        assert self._edge_feats_shape is not None
         shape = (
             max_time + 1,
             max_node_id + 1,
@@ -229,25 +250,14 @@ class DGStorageArrayBackend(DGStorageBase):
 
         return torch.sparse_coo_tensor(indices_tensor, values_tensor, shape)
 
-    def _valid_slice(
-        self,
-        event: Event,
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
-        node_slice: Optional[Set[int]] = None,
-    ) -> bool:
-        lb_time = float('-inf') if start_time is None else start_time
-        ub_time = float('inf') if end_time is None else end_time
+    def _lb_time_idx(self, t: Optional[int]) -> int:
+        if t not in self._lb_idx_cache:
+            tt = self._ts[0] if t is None else t
+            self._lb_idx_cache[t] = int(np.searchsorted(self._ts, tt))
+        return self._lb_idx_cache[t]
 
-        time_valid = lb_time <= event.t <= ub_time
-        node_valid = (
-            node_slice is None
-            or (isinstance(event, NodeEvent) and event.src in node_slice)
-            or (
-                isinstance(event, EdgeEvent)
-                and len(set(event.edge).intersection(node_slice)) > 0
-            )
-        )
-        # TODO: This can be optimized by returning these seperately, and hence early
-        # returning out of the event loop if we already know the timestamp is not valid
-        return time_valid and node_valid
+    def _ub_time_idx(self, t: Optional[int]) -> int:
+        if t not in self._ub_idx_cache:
+            tt = self._ts[-1] if t is None else t
+            self._ub_idx_cache[t] = int(np.searchsorted(self._ts, tt, side='right'))
+        return self._ub_idx_cache[t]

--- a/opendg/_storage/backends/array_backend.py
+++ b/opendg/_storage/backends/array_backend.py
@@ -15,9 +15,7 @@ class DGStorageArrayBackend(DGStorageBase):
     def __init__(self, events: List[Event]) -> None:
         self._node_feats_shape = self._check_node_feature_shapes(events)
         self._edge_feats_shape = self._check_edge_feature_shapes(events)
-        # TODO: Maintain sorted list invariant and create temporal index
-        # to avoid brute force linear search when start/end times are given
-        self._events = events[:]  # Make a copy
+        self._events = self._sort_events_list_if_needed(events[:])  # Make a copy
 
     def to_events(
         self,

--- a/opendg/graph.py
+++ b/opendg/graph.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pathlib
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, List, Optional, Set, Tuple
+from typing import Any, List, Optional, Set
 
 import pandas as pd
 from torch import Tensor
@@ -53,11 +53,11 @@ class DGraph:
         dg = DGraph(data=self._storage, time_delta=self.time_delta)
 
         # Update start time
-        dg._slice.start_time = self._maybe_max((start_time, self.start_time))
+        dg._slice.start_time = self._maybe_max(start_time, self.start_time)
         force_refresh_node_slice = dg._slice.start_time == self.start_time
 
         # Update end time
-        dg._slice.end_time = self._maybe_min((end_time, self.end_time))
+        dg._slice.end_time = self._maybe_min(end_time, self.end_time)
         force_refresh_node_slice &= dg._slice.end_time == self.end_time
 
         if not force_refresh_node_slice:
@@ -75,12 +75,12 @@ class DGraph:
 
         # Update start time
         dg._slice.start_time = self._maybe_max(
-            (self._storage.get_start_time(dg._slice.node_slice), self.start_time)
+            self._storage.get_start_time(dg._slice.node_slice), self.start_time
         )
 
         # Update end time
         dg._slice.end_time = self._maybe_min(
-            (self._storage.get_end_time(dg._slice.node_slice), self.end_time)
+            self._storage.get_end_time(dg._slice.node_slice), self.end_time
         )
 
         return dg
@@ -151,12 +151,16 @@ class DGraph:
         )
 
     @staticmethod
-    def _maybe_max(seq: Tuple[Any, Any]) -> Optional[int]:
-        return max(filter(lambda x: x is not None, seq), default=None)
+    def _maybe_max(a: Any, b: Any) -> Optional[int]:
+        if a is not None and b is not None:
+            return max(a, b)
+        return a if b is None else b if a is None else None
 
     @staticmethod
-    def _maybe_min(seq: Tuple[Any, Any]) -> Optional[int]:
-        return min(filter(lambda x: x is not None, seq), default=None)
+    def _maybe_min(a: Any, b: Any) -> Optional[int]:
+        if a is not None and b is not None:
+            return min(a, b)
+        return a if b is None else b if a is None else None
 
 
 @dataclass(slots=True)

--- a/opendg/loader/base.py
+++ b/opendg/loader/base.py
@@ -70,13 +70,10 @@ class DGBaseLoader(ABC):
         return self
 
     def __next__(self) -> DGraph:
-        if self._done_iteration():
+        check_idx = self._idx + self._batch_size - 1 if self._drop_last else self._idx
+        if check_idx > self._stop_idx:
             raise StopIteration
 
         batch = self._dg.slice_time(self._idx, self._idx + self._batch_size - 1)
         self._idx += self._batch_size
         return self.sample(batch)
-
-    def _done_iteration(self) -> bool:
-        check_idx = self._idx + self._batch_size - 1 if self._drop_last else self._idx
-        return check_idx > self._stop_idx

--- a/test/test_storage_impl.py
+++ b/test/test_storage_impl.py
@@ -87,6 +87,18 @@ def events_list_with_features_multi_events_per_timestamp():
     ]
 
 
+@pytest.fixture
+def events_list_out_of_time_order():
+    return [
+        EdgeEvent(t=5, src=2, dst=4),
+        NodeEvent(t=10, src=6),
+        NodeEvent(t=1, src=2),
+        NodeEvent(t=5, src=4),
+        EdgeEvent(t=20, src=1, dst=8),
+        EdgeEvent(t=1, src=2, dst=2),
+    ]
+
+
 def test_empty_events_list_to_events(DGStorageImpl, empty_events_list):
     storage = DGStorageImpl(empty_events_list)
     assert storage.to_events() == empty_events_list
@@ -168,6 +180,20 @@ def test_init_incompatible_edge_feature_dimension(DGStorageImpl):
         NodeEvent(t=6, src=7, msg=torch.rand(3, 6)),
     ]
 
+    with pytest.raises(ValueError):
+        _ = DGStorageImpl(events)
+
+
+def test_init_out_of_order_events_list(DGStorageImpl, events_list_out_of_time_order):
+    with pytest.warns(UserWarning):
+        _ = DGStorageImpl(events_list_out_of_time_order)
+
+
+def test_init_non_event_type(DGStorageImpl):
+    events = [
+        EdgeEvent(t=1, src=2, dst=3),
+        'foo',  # Should raise
+    ]
     with pytest.raises(ValueError):
         _ = DGStorageImpl(events)
 


### PR DESCRIPTION
Close #88

### Purpose
The purpose of this PR is to use the sortedness of the events list to speed up and simplify the `ArrayBackend`. I also made several micro optimizations which you can read in the code.

### Complexity
The complexity is clearly better but we would need to add more exhaustive perf testing to truly see the benefits.

All time-dependant storage queries are reduced from $$\mathcal{O}(|Events|)$$ down to $$\mathcal{O}(|time range|)$$ (plus an additional overhead of $$\mathcal{O}|log|T||$$ which happens only once to cache the time bounds).

We pay an extra $$|4 * T| $$ bytes of memory to store a time array (+ extra cache space) 
This will be much faster if our time slices are relatively small compared to the entire graph.

### Perf Results
Since we don't have exhaustive perf tests it's not clear how much we save end-to-end, but this is the single benchmark I have implemented which has been used in my previous prs (iterating a `DGraph` with 1M events)

**Control (`openDG::main`)**
![foo](https://github.com/user-attachments/assets/dc98d7a4-0cd1-4c0c-9d12-c58c97b3a70a)


**Case (`openDG::devsorted_perf`)**
![foo](https://github.com/user-attachments/assets/00ad04aa-400e-4ae4-9d6e-f0d331964dae)


